### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - published
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DEFAULT_PYTHON: "3.10"
 


### PR DESCRIPTION
Potential fix for [https://github.com/john0isaac/protect-my-dir/security/code-scanning/1](https://github.com/john0isaac/protect-my-dir/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (or to the specific job) that grants only the minimal scopes needed for `GITHUB_TOKEN`. For this workflow, the job checks out code and builds/uploads to PyPI using a separate secret, so `contents: read` is sufficient. No write permissions via `GITHUB_TOKEN` are needed.

The best minimal change without altering existing functionality is to add a `permissions` block at the root level of `.github/workflows/release.yml` so it applies to all jobs in this workflow. We can place it after the `on:` block and before `env:`. This block will declare `contents: read`, which provides enough access for `actions/checkout` to work while preventing `GITHUB_TOKEN` from being used for unintended write operations. No imports or extra methods are required because this is a YAML configuration change only.

Specifically, in `.github/workflows/release.yml`, between the existing `workflow_dispatch:` (line 7) and `env:` (line 9), insert:

```yaml
permissions:
  contents: read
```

No other parts of the workflow need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
